### PR TITLE
fix: vec type husker also processes single-field composites

### DIFF
--- a/src/decoding_sci.rs
+++ b/src/decoding_sci.rs
@@ -591,6 +591,8 @@ struct HuskedType<'a> {
     ty: &'a Type<PortableForm>,
 }
 
+const HUSKER_DEPTH: u8 = 10;
+
 fn husk_type<'a>(
     entry_symbol: &'a UntrackedSymbol<std::any::TypeId>,
     meta_v14: &'a RuntimeMetadataV14,
@@ -599,6 +601,8 @@ fn husk_type<'a>(
     let mut info: Vec<Info> = Vec::new();
     let mut is_compact = false;
     let mut hint = Hint::None;
+
+    let mut husker_counter = 0;
 
     loop {
         let info_ty = Info::from_ty(ty);
@@ -625,6 +629,12 @@ fn husk_type<'a>(
                 }
                 _ => break,
             }
+        } else {
+            break;
+        }
+
+        if husker_counter < HUSKER_DEPTH {
+            husker_counter += 1
         } else {
             break;
         }

--- a/src/decoding_sci.rs
+++ b/src/decoding_sci.rs
@@ -432,7 +432,7 @@ pub fn decode_elements_set(
                     &Ty::Resolved(husked.ty),
                     data,
                     meta_v14,
-                    Propagated::with_compact(husked.is_compact),
+                    Propagated::with_specialty_set(husked.specialty_set),
                 )?;
                 out.push(element_extended_data.data);
             }
@@ -587,7 +587,7 @@ fn decode_type_def_bit_sequence(
 
 struct HuskedType<'a> {
     info: Vec<Info>,
-    is_compact: bool,
+    specialty_set: SpecialtySet,
     ty: &'a Type<PortableForm>,
 }
 
@@ -595,31 +595,46 @@ fn husk_type<'a>(
     entry_symbol: &'a UntrackedSymbol<std::any::TypeId>,
     meta_v14: &'a RuntimeMetadataV14,
 ) -> Result<HuskedType<'a>, ParserError> {
-    let mut is_compact = false;
-
     let mut ty = resolve_ty(meta_v14, entry_symbol.id())?;
+    let mut info: Vec<Info> = Vec::new();
+    let mut is_compact = false;
+    let mut hint = Hint::None;
 
-    let info_ty = Info::from_ty(ty);
-    let mut info = {
-        if info_ty.is_empty() {
-            Vec::new()
-        } else {
-            vec![info_ty]
-        }
-    };
-
-    if let TypeDef::Compact(x) = ty.type_def() {
-        is_compact = true;
-        ty = resolve_ty(meta_v14, x.type_param().id())?;
+    loop {
         let info_ty = Info::from_ty(ty);
         if !info_ty.is_empty() {
             info.push(info_ty)
         }
+
+        if let SpecialtyTypeHinted::None = SpecialtyTypeHinted::from_path(ty.path()) {
+            match ty.type_def() {
+                TypeDef::Composite(x) => {
+                    let fields = x.fields();
+                    if fields.len() == 1 {
+                        ty = resolve_ty(meta_v14, fields[0].ty().id())?;
+                        if let Hint::None = hint {
+                            hint = Hint::from_field(&fields[0])
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                TypeDef::Compact(x) => {
+                    is_compact = true;
+                    ty = resolve_ty(meta_v14, x.type_param().id())?;
+                }
+                _ => break,
+            }
+        } else {
+            break;
+        }
     }
+
+    let specialty_set = SpecialtySet { hint, is_compact };
 
     Ok(HuskedType {
         info,
-        is_compact,
+        specialty_set,
         ty,
     })
 }

--- a/src/special_indicators.rs
+++ b/src/special_indicators.rs
@@ -313,15 +313,6 @@ impl Propagated {
             info: Vec::new(),
         }
     }
-    pub fn with_compact(is_compact: bool) -> Self {
-        Self {
-            specialty_set: SpecialtySet {
-                is_compact,
-                hint: Hint::None,
-            },
-            info: Vec::new(),
-        }
-    }
     pub fn with_specialty_set(specialty_set: SpecialtySet) -> Self {
         Self {
             specialty_set,
@@ -383,8 +374,24 @@ impl Default for Propagated {
 /// Gets checked each time a new type is encountered.
 pub enum SpecialtyTypeHinted {
     None,
+    AccountId32,
+    Era,
+    H160,
+    H256,
+    H512,
     Option,
     PalletSpecific(PalletSpecificItem),
+    Perbill,
+    Percent,
+    Permill,
+    Perquintill,
+    PerU16,
+    PublicEd25519,
+    PublicSr25519,
+    PublicEcdsa,
+    SignatureEd25519,
+    SignatureSr25519,
+    SignatureEcdsa,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -397,9 +404,43 @@ impl SpecialtyTypeHinted {
     pub fn from_path(path: &Path<PortableForm>) -> Self {
         match path.ident() {
             Some(a) => match a.as_str() {
+                ACCOUNT_ID32 => Self::AccountId32,
                 CALL => Self::PalletSpecific(PalletSpecificItem::Call),
+                ERA => Self::Era,
                 EVENT => Self::PalletSpecific(PalletSpecificItem::Event),
+                a if H160.contains(&a) => Self::H160,
+                H256 => Self::H256,
+                H512 => Self::H512,
                 OPTION => Self::Option,
+                PERBILL => Self::Perbill,
+                PERCENT => Self::Percent,
+                PERMILL => Self::Permill,
+                PERQUINTILL => Self::Perquintill,
+                PERU16 => Self::PerU16,
+                PUBLIC => match path
+                    .namespace()
+                    .iter()
+                    .map(|x| x.as_str())
+                    .collect::<Vec<&str>>()
+                    .as_ref()
+                {
+                    SP_CORE_ED25519 => Self::PublicEd25519,
+                    SP_CORE_SR25519 => Self::PublicSr25519,
+                    SP_CORE_ECDSA => Self::PublicEcdsa,
+                    _ => Self::None,
+                },
+                SIGNATURE => match path
+                    .namespace()
+                    .iter()
+                    .map(|x| x.as_str())
+                    .collect::<Vec<&str>>()
+                    .as_ref()
+                {
+                    SP_CORE_ED25519 => Self::SignatureEd25519,
+                    SP_CORE_SR25519 => Self::SignatureSr25519,
+                    SP_CORE_ECDSA => Self::SignatureEcdsa,
+                    _ => Self::None,
+                },
                 _ => Self::None,
             },
             None => Self::None,
@@ -442,6 +483,12 @@ impl<'a> SpecialtyTypeChecked<'a> {
     ) -> Self {
         let path = ty.path();
         match SpecialtyTypeHinted::from_path(path) {
+            SpecialtyTypeHinted::None => Self::None,
+            SpecialtyTypeHinted::AccountId32 => Self::AccountId32,
+            SpecialtyTypeHinted::Era => Self::Era,
+            SpecialtyTypeHinted::H160 => Self::H160,
+            SpecialtyTypeHinted::H256 => Self::H256,
+            SpecialtyTypeHinted::H512 => Self::H512,
             SpecialtyTypeHinted::Option => {
                 if let TypeDef::Variant(x) = ty.type_def() {
                     let params = ty.type_params();
@@ -518,46 +565,17 @@ impl<'a> SpecialtyTypeChecked<'a> {
                     Self::None
                 }
             }
-            SpecialtyTypeHinted::None => match path.ident() {
-                Some(a) => match a.as_str() {
-                    ACCOUNT_ID32 => Self::AccountId32,
-                    ERA => Self::Era,
-                    a if H160.contains(&a) => Self::H160,
-                    H256 => Self::H256,
-                    H512 => Self::H512,
-                    PERBILL => Self::Perbill,
-                    PERCENT => Self::Percent,
-                    PERMILL => Self::Permill,
-                    PERQUINTILL => Self::Perquintill,
-                    PERU16 => Self::PerU16,
-                    PUBLIC => match path
-                        .namespace()
-                        .iter()
-                        .map(|x| x.as_str())
-                        .collect::<Vec<&str>>()
-                        .as_ref()
-                    {
-                        SP_CORE_ED25519 => Self::PublicEd25519,
-                        SP_CORE_SR25519 => Self::PublicSr25519,
-                        SP_CORE_ECDSA => Self::PublicEcdsa,
-                        _ => Self::None,
-                    },
-                    SIGNATURE => match path
-                        .namespace()
-                        .iter()
-                        .map(|x| x.as_str())
-                        .collect::<Vec<&str>>()
-                        .as_ref()
-                    {
-                        SP_CORE_ED25519 => Self::SignatureEd25519,
-                        SP_CORE_SR25519 => Self::SignatureSr25519,
-                        SP_CORE_ECDSA => Self::SignatureEcdsa,
-                        _ => Self::None,
-                    },
-                    _ => Self::None,
-                },
-                None => Self::None,
-            },
+            SpecialtyTypeHinted::Perbill => Self::Perbill,
+            SpecialtyTypeHinted::Percent => Self::Percent,
+            SpecialtyTypeHinted::Permill => Self::Permill,
+            SpecialtyTypeHinted::Perquintill => Self::Perquintill,
+            SpecialtyTypeHinted::PerU16 => Self::PerU16,
+            SpecialtyTypeHinted::PublicEd25519 => Self::PublicEd25519,
+            SpecialtyTypeHinted::PublicSr25519 => Self::PublicSr25519,
+            SpecialtyTypeHinted::PublicEcdsa => Self::PublicEcdsa,
+            SpecialtyTypeHinted::SignatureEd25519 => Self::SignatureEd25519,
+            SpecialtyTypeHinted::SignatureSr25519 => Self::SignatureSr25519,
+            SpecialtyTypeHinted::SignatureEcdsa => Self::SignatureEcdsa,
         }
     }
 }


### PR DESCRIPTION
Allow vec type husker to process single field compacts, until (unless) recognizable specialty is encountered.