### PR TITLE
chore: modify to pub

### DIFF
--- a/src/compacts.rs
+++ b/src/compacts.rs
@@ -70,7 +70,7 @@ where
 }
 
 /// Find compact and move current parser position accordingly.
-pub(crate) fn get_compact<T, B, E>(
+pub fn get_compact<T, B, E>(
     data: &B,
     ext_memory: &mut E,
     position: &mut usize,

--- a/src/decoding_sci.rs
+++ b/src/decoding_sci.rs
@@ -51,7 +51,7 @@ use crate::MarkedData;
 ///
 /// Current parser position gets changed. Propagated to this point
 /// [`SpecialtySet`] is used.
-pub(crate) fn decode_type_def_primitive<B, E>(
+pub fn decode_type_def_primitive<B, E>(
     found_ty: &TypeDefPrimitive,
     data: &B,
     ext_memory: &mut E,
@@ -297,7 +297,7 @@ where
 }
 
 /// [`TypeParameter`](scale_info::TypeParameter) name for `call`.
-pub(crate) const CALL_INDICATOR: &str = "Call";
+pub const CALL_INDICATOR: &str = "Call";
 
 /// General decoder function. Parse part of data as [`Ty`].
 ///
@@ -809,7 +809,7 @@ where
 /// First data `u8` element is `index` of [`Variant`].
 ///
 /// Does not modify the input.
-pub(crate) fn pick_variant<'a, B, E>(
+pub fn pick_variant<'a, B, E>(
     variants: &'a [Variant<PortableForm>],
     data: &B,
     ext_memory: &mut E,
@@ -998,7 +998,7 @@ where
 }
 
 /// Positions and related values for decoding `BitVec`.
-pub(crate) struct BitVecPositions {
+pub struct BitVecPositions {
     /// Encoded `BitVec` start position, includes bit length compact.
     bitvec_start: usize,
 
@@ -1007,7 +1007,7 @@ pub(crate) struct BitVecPositions {
     data_start: usize,
 
     /// Encoded `BitVec` end position.
-    pub(crate) bitvec_end: usize,
+    pub bitvec_end: usize,
 
     /// Number of bits in `BitVec`, for patch only.
     #[cfg(any(target_pointer_width = "32", test))]
@@ -1025,7 +1025,7 @@ impl BitVecPositions {
     /// New `BitVecPositions` for given input data and position.
     ///
     /// `T` is corresponding `BitStore`.
-    pub(crate) fn new<T, B, E>(
+    pub fn new<T, B, E>(
         data: &B,
         ext_memory: &mut E,
         position: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,11 +464,11 @@ pub mod additional_types;
 pub mod cards;
 pub mod compacts;
 pub mod cut_metadata;
-mod decoding_sci;
+pub mod decoding_sci;
 mod decoding_sci_ext;
 pub mod error;
 pub mod printing_balance;
-mod propagated;
+pub mod propagated;
 pub mod special_indicators;
 mod special_types;
 pub mod storage_data;
@@ -565,7 +565,7 @@ where
     ///
     /// Extensions are cut to ensure the call decoding never gets outside the
     /// call data.
-    pub(crate) fn data_no_extensions(&self) -> B {
+    pub fn data_no_extensions(&self) -> B {
         self.data.limit_length(self.extensions_start())
     }
 

--- a/src/propagated.rs
+++ b/src/propagated.rs
@@ -189,12 +189,12 @@ impl Default for Checker {
 #[derive(Clone, Debug)]
 pub struct Propagated {
     /// Type data that is collected and checked during parsing.
-    pub(crate) checker: Checker,
+    pub checker: Checker,
 
     /// Set of [`Info`] collected while resolving the type.
     ///
     /// Only non-empty [`Info`] entries are added.
-    pub(crate) info: Vec<Info>,
+    pub info: Vec<Info>,
 }
 
 impl Propagated {
@@ -207,7 +207,7 @@ impl Propagated {
     }
 
     /// Initiate new `Propagated` for signed extensions instance.
-    pub(crate) fn from_ext_meta(signed_ext_meta: &SignedExtensionMetadata<PortableForm>) -> Self {
+    pub fn from_ext_meta(signed_ext_meta: &SignedExtensionMetadata<PortableForm>) -> Self {
         Self {
             checker: Checker {
                 specialty_set: SpecialtySet {
@@ -221,7 +221,7 @@ impl Propagated {
     }
 
     /// Initiate new `Propagated` with known, propagated from above `Checker`.
-    pub(crate) fn with_checker(checker: Checker) -> Self {
+    pub fn with_checker(checker: Checker) -> Self {
         Self {
             checker,
             info: Vec::new(),
@@ -230,7 +230,7 @@ impl Propagated {
 
     /// Initiate new `Propagated` with known, propagated from above `Checker`
     /// for an individual [`Field`].
-    pub(crate) fn for_field<E: ExternalMemory>(
+    pub fn for_field<E: ExternalMemory>(
         checker: &Checker,
         field: &Field<PortableForm>,
     ) -> Result<Self, ParserError<E>> {
@@ -242,7 +242,7 @@ impl Propagated {
 
     /// Initiate new `Propagated` with known, propagated from above `Checker`
     /// for a [`Type`].
-    pub(crate) fn for_ty<E: ExternalMemory>(
+    pub fn for_ty<E: ExternalMemory>(
         checker: &Checker,
         ty: &Type<PortableForm>,
         id: u32,
@@ -254,30 +254,30 @@ impl Propagated {
     }
 
     /// Get associated `compact_at`
-    pub(crate) fn compact_at(&self) -> Option<u32> {
+    pub fn compact_at(&self) -> Option<u32> {
         self.checker.specialty_set.compact_at
     }
 
     /// Check that `compact_at` field in associated [`SpecialtySet`] is not
     /// `Some(_)`, i.e. there was no compact type encountered.
-    pub(crate) fn reject_compact<E: ExternalMemory>(&self) -> Result<(), ParserError<E>> {
+    pub fn reject_compact<E: ExternalMemory>(&self) -> Result<(), ParserError<E>> {
         self.checker.specialty_set.reject_compact::<E>()
     }
 
     /// Discard previously found [`Hint`].
-    pub(crate) fn forget_hint(&mut self) {
+    pub fn forget_hint(&mut self) {
         self.checker.forget_hint()
     }
 
     /// Add [`Info`] entry (if non-empty) to `info` set.
-    pub(crate) fn add_info(&mut self, info_update: &Info) {
+    pub fn add_info(&mut self, info_update: &Info) {
         if !info_update.is_empty() {
             self.info.push(info_update.clone())
         }
     }
 
     /// Add `&[Info]` to `info` set.
-    pub(crate) fn add_info_slice(&mut self, info_update_slice: &[Info]) {
+    pub fn add_info_slice(&mut self, info_update_slice: &[Info]) {
         self.info.extend_from_slice(info_update_slice)
     }
 }


### PR DESCRIPTION
some `pub(crate)` changed into `pub`, to separate metadata shortener crate