### PR TITLE
chore: separate AsMetadata and AsCompleteMetadata

### DIFF
--- a/src/decoding_sci.rs
+++ b/src/decoding_sci.rs
@@ -207,12 +207,10 @@ where
     E: ExternalMemory,
     M: AsMetadata<E>,
 {
-    let extrinsic_type_params = metadata
-        .extrinsic_type_params()
-        .map_err(SignableError::MetaStructure)?;
+    let call_ty = metadata.call_ty().map_err(SignableError::MetaStructure)?;
 
     let call_extended_data = decode_with_type::<B, E, M>(
-        &Ty::Symbol(&extrinsic_type_params.call_ty),
+        &Ty::Symbol(&call_ty),
         data,
         ext_memory,
         position,
@@ -222,7 +220,7 @@ where
     if let ParsedData::Call(call) = call_extended_data.data {
         Ok(call)
     } else {
-        Err(SignableError::NotACall(extrinsic_type_params.call_ty.id))
+        Err(SignableError::NotACall(call_ty.id))
     }
 }
 

--- a/src/unchecked_extrinsic.rs
+++ b/src/unchecked_extrinsic.rs
@@ -54,7 +54,7 @@ use crate::cards::{Call, ExtendedData, ParsedData};
 use crate::compacts::get_compact;
 use crate::decode_as_type_at_position;
 use crate::error::{ParserError, UncheckedExtrinsicError};
-use crate::traits::AsMetadata;
+use crate::traits::AsCompleteMetadata;
 
 /// Length of version indicator, 1 byte.
 const VERSION_LENGTH: usize = 1;
@@ -74,7 +74,7 @@ pub fn decode_as_unchecked_extrinsic<B, E, M>(
 where
     B: AddressableBuffer<E>,
     E: ExternalMemory,
-    M: AsMetadata<E>,
+    M: AsCompleteMetadata<E>,
 {
     let extrinsic_type_params = metadata
         .extrinsic_type_params()


### PR DESCRIPTION
So that shortened metadata is not forced to have additional info (unnecessary for transaction parsing) to comply.